### PR TITLE
Add WooCommerce spider and --platform flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Shopify Spy is a command-line tool for scraping product and collection data from any Shopify store. Built on [Scrapy](https://docs.scrapy.org/en/latest/index.html), it extracts detailed data including high-value information like vendor names and inventory levels.
+Shopify Spy is a command-line tool for scraping product and collection data from ecommerce stores. Built on [Scrapy](https://docs.scrapy.org/en/latest/index.html), it supports Shopify and WooCommerce stores out of the box.
 
 To find Shopify stores to scrape, try searching Google with `site:myshopify.com`.
 
@@ -34,8 +34,11 @@ Requires Python 3.10+.
 ## Quick Start
 
 ```bash
-# Scrape a single store
+# Scrape a Shopify store (default)
 shopify-spy scrape https://www.example.com
+
+# Scrape a WooCommerce store
+shopify-spy scrape --platform woocommerce https://www.example.com
 
 # Scrape multiple stores
 shopify-spy scrape https://store1.com https://store2.com https://store3.com
@@ -43,7 +46,7 @@ shopify-spy scrape https://store1.com https://store2.com https://store3.com
 # Download product images
 shopify-spy scrape https://www.example.com --images
 
-# Include collections
+# Include collections (Shopify only)
 shopify-spy scrape https://www.example.com --collections
 
 # Scrape multiple stores from a file
@@ -55,23 +58,31 @@ shopify-spy scrape https://www.example.com --output ./my-data
 
 Results are saved as JSONL in the output directory (default: `./output`). Use `--format` to choose JSON, CSV, or XML instead.
 
+## Supported Platforms
+
+| Platform | Mechanism | Notes |
+|---|---|---|
+| Shopify | `/sitemap.xml` + `.json` endpoints | Products and collections |
+| WooCommerce | `/wp-json/wc/store/v1/products` | No authentication required |
+
 ## Commands
 
 ### `scrape`
 
-Scrape products and collections from Shopify stores.
+Scrape products and collections from Shopify and WooCommerce stores.
 
 ```bash
 shopify-spy scrape [URL] [OPTIONS]
 ```
 
 **Arguments:**
-- `URL...` - One or more Shopify store URLs (optional if using `--url-file`)
+- `URL...` - One or more store URLs (optional if using `--url-file`)
 
 **Options:**
+- `--platform, -p PLATFORM` - Ecommerce platform: `shopify`, `woocommerce` (default: `shopify`)
 - `--url-file, -f FILE` - File containing URLs (one per line)
-- `--products / --no-products` - Scrape products (default: yes)
-- `--collections / --no-collections` - Scrape collections (default: no)
+- `--products / --no-products` - Scrape products (default: yes; Shopify only)
+- `--collections / --no-collections` - Scrape collections (default: no; Shopify only)
 - `--images / --no-images` - Download images (default: no)
 - `--output, -o PATH` - Output directory (default: `./output`)
 - `--format, -F FORMAT` - Output format: `json`, `jsonl`, `csv`, `xml` (default: `jsonl`)
@@ -103,8 +114,9 @@ Shopify Spy can be configured via YAML file. Create one with `shopify-spy init`:
 ```yaml
 # shopify-spy.yaml
 scrape:
-  products: true      # Scrape product data
-  collections: false  # Scrape collection data
+  platform: shopify   # Platform: shopify, woocommerce
+  products: true      # Scrape product data (Shopify only)
+  collections: false  # Scrape collection data (Shopify only)
   images: false       # Download product images
 
 output:
@@ -145,7 +157,38 @@ output/
       <image files>
 ```
 
-Each line in the JSON file contains a product or collection with full metadata from Shopify's JSON API.
+### Shopify output
+
+Each line contains the full product or collection JSON from Shopify's API, plus two added fields:
+
+```json
+{
+  "product": { "title": "...", "variants": [...], "images": [...], ... },
+  "url": "https://store.com/products/item.json",
+  "store": "store.com",
+  "image_urls": ["https://cdn.shopify.com/.../product.jpg"]
+}
+```
+
+### WooCommerce output
+
+Each line contains the full product JSON from the WooCommerce Store API, plus two added fields:
+
+```json
+{
+  "id": 123,
+  "name": "Product Name",
+  "slug": "product-name",
+  "permalink": "https://store.com/product/product-name/",
+  "sku": "SKU-001",
+  "prices": { "price": "5200", "currency_code": "USD", "currency_minor_unit": 2 },
+  "images": [{ "id": 1, "src": "https://..." }],
+  "store": "store.com",
+  "image_urls": ["https://..."]
+}
+```
+
+Note: WooCommerce prices are strings in minor currency units (divide by `10^currency_minor_unit` to get the decimal value).
 
 ### Image Metadata
 
@@ -161,8 +204,7 @@ When using `--images`, each item includes a `scraped_images` field with download
       "checksum": "d41d8cd98f00b204e9800998ecf8427e",
       "status": "downloaded"
     }
-  ],
-  "product": { ... }
+  ]
 }
 ```
 
@@ -172,11 +214,11 @@ The `path` is relative to the images directory (`output/images/` by default).
 
 **With jq:**
 ```bash
-# Extract product titles
+# Shopify: extract product titles
 cat output/*.jsonl | jq '.product.title'
 
-# Get prices
-cat output/*.jsonl | jq '{title: .product.title, price: .product.variants[0].price}'
+# WooCommerce: extract product names and prices
+cat output/*.jsonl | jq '{name: .name, price: .prices.price, currency: .prices.currency_code}'
 ```
 
 **With Python:**
@@ -186,7 +228,8 @@ import json
 with open("output/shopify_spider_2024-01-15.jsonl") as f:
     for line in f:
         item = json.loads(line)
-        print(item["product"]["title"])
+        print(item["product"]["title"])  # Shopify
+        # print(item["name"])            # WooCommerce
 ```
 
 **With pandas:**
@@ -194,7 +237,7 @@ with open("output/shopify_spider_2024-01-15.jsonl") as f:
 import pandas as pd
 
 df = pd.read_json("output/shopify_spider_2024-01-15.jsonl", lines=True)
-products = pd.json_normalize(df["product"])
+products = pd.json_normalize(df["product"])  # Shopify
 ```
 
 **With polars:**
@@ -207,6 +250,8 @@ df = pl.read_ndjson("output/shopify_spider_2024-01-15.jsonl")
 ## Limitations
 
 **Standard Shopify stores only.** This tool works with standard Shopify stores using Liquid themes, which represent nearly all Shopify sites. The small number of headless stores built on [Hydrogen](https://hydrogen.shopify.dev/) or other custom storefronts are not supported, as they use the Storefront GraphQL API instead of the JSON endpoints this tool relies on.
+
+**WooCommerce Store API required.** The WooCommerce spider uses the public Store API (`/wp-json/wc/store/v1/products`), available in WooCommerce 3.x and later. Stores that have disabled the REST API via security plugins, or that broadly block crawlers in `robots.txt`, will not be scrapeable.
 
 **Rate limiting.** Scraping very large stores may still result in temporary bans. Auto-throttling is enabled by default, but you can adjust the settings or disable it for faster scraping:
 
@@ -223,9 +268,16 @@ For advanced Scrapy configuration or custom pipelines, you can use Shopify Spy a
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
 from shopify_spy.spiders.shopify import ShopifySpider
+from shopify_spy.spiders.woocommerce import WooCommerceSpider
 
 process = CrawlerProcess(get_project_settings())
+
+# Shopify
 process.crawl(ShopifySpider, url="https://example.com", products=True)
+
+# WooCommerce
+process.crawl(WooCommerceSpider, url="https://example.com")
+
 process.start()
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shopify-spy"
-version = "0.1.2"
+version = "0.2.0"
 description = "Simple CLI to scrape product data, images, and collections from Shopify stores"
 readme = "README.md"
 license = "MIT"

--- a/shopify_spy/cli.py
+++ b/shopify_spy/cli.py
@@ -139,6 +139,7 @@ def scrape(
     # Apply CLI overrides
     config = apply_cli_overrides(
         config,
+        platform=platform,
         products=products,
         collections=collections,
         images=images,
@@ -164,7 +165,7 @@ def scrape(
     log_level = "DEBUG" if verbose else "WARNING" if quiet else None
 
     # Run the spider
-    run_spider(all_urls, config, log_level=log_level, platform=platform)
+    run_spider(all_urls, config, log_level=log_level)
 
 
 @app.command()
@@ -194,6 +195,7 @@ def init(
 def apply_cli_overrides(
     config: Config,
     *,
+    platform: Platform | None,
     products: bool | None,
     collections: bool | None,
     images: bool | None,
@@ -211,6 +213,8 @@ def apply_cli_overrides(
     network_dict = config.network.model_dump()
     throttle_dict = config.throttle.model_dump()
 
+    if platform is not None:
+        scrape_dict["platform"] = platform.value
     if products is not None:
         scrape_dict["products"] = products
     if collections is not None:
@@ -260,14 +264,13 @@ def run_spider(
     urls: list[str],
     config: Config,
     log_level: str | None = None,
-    platform: Platform = Platform.shopify,
 ) -> None:
     """Run the appropriate spider with the given configuration."""
     # Deferred imports to avoid loading Scrapy until needed
     from scrapy.crawler import CrawlerProcess
     from scrapy.utils.project import get_project_settings
 
-    if platform == Platform.woocommerce:
+    if config.scrape.platform == "woocommerce":
         from shopify_spy.spiders.woocommerce import WooCommerceSpider
 
         spider_cls = WooCommerceSpider
@@ -328,8 +331,8 @@ def run_spider(
         settings.set("ITEM_PIPELINES", {})
 
     console.print(f"[bold]Scraping {len(urls)} store(s)...[/bold]")
-    console.print(f"  Platform: {platform.value}")
-    if platform == Platform.shopify:
+    console.print(f"  Platform: {config.scrape.platform}")
+    if config.scrape.platform == "shopify":
         console.print(f"  Products: {config.scrape.products}")
         console.print(f"  Collections: {config.scrape.collections}")
     console.print(f"  Images: {config.scrape.images}")

--- a/shopify_spy/cli.py
+++ b/shopify_spy/cli.py
@@ -1,7 +1,6 @@
 """Command-line interface for Shopify Spy."""
 
 import sys
-from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
@@ -12,15 +11,10 @@ from shopify_spy.config import (
     OUTPUT_FORMATS,
     Config,
     OutputFormat,
+    Platform,
     create_default_config,
     load_config,
 )
-
-
-class Platform(str, Enum):
-    shopify = "shopify"
-    woocommerce = "woocommerce"
-
 
 app = typer.Typer(
     name="shopify-spy",
@@ -214,7 +208,7 @@ def apply_cli_overrides(
     throttle_dict = config.throttle.model_dump()
 
     if platform is not None:
-        scrape_dict["platform"] = platform.value
+        scrape_dict["platform"] = platform
     if products is not None:
         scrape_dict["products"] = products
     if collections is not None:
@@ -270,7 +264,7 @@ def run_spider(
     from scrapy.crawler import CrawlerProcess
     from scrapy.utils.project import get_project_settings
 
-    if config.scrape.platform == "woocommerce":
+    if config.scrape.platform == Platform.woocommerce:
         from shopify_spy.spiders.woocommerce import WooCommerceSpider
 
         spider_cls = WooCommerceSpider
@@ -332,7 +326,7 @@ def run_spider(
 
     console.print(f"[bold]Scraping {len(urls)} store(s)...[/bold]")
     console.print(f"  Platform: {config.scrape.platform}")
-    if config.scrape.platform == "shopify":
+    if config.scrape.platform == Platform.shopify:
         console.print(f"  Products: {config.scrape.products}")
         console.print(f"  Collections: {config.scrape.collections}")
     console.print(f"  Images: {config.scrape.images}")

--- a/shopify_spy/cli.py
+++ b/shopify_spy/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for Shopify Spy."""
 
 import sys
+from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
@@ -14,6 +15,12 @@ from shopify_spy.config import (
     create_default_config,
     load_config,
 )
+
+
+class Platform(str, Enum):
+    shopify = "shopify"
+    woocommerce = "woocommerce"
+
 
 app = typer.Typer(
     name="shopify-spy",
@@ -52,7 +59,7 @@ def main(
 def scrape(
     urls: Annotated[
         list[str] | None,
-        typer.Argument(help="Shopify store URL(s) to scrape."),
+        typer.Argument(help="Store URL(s) to scrape."),
     ] = None,
     url_file: Annotated[
         Path | None,
@@ -112,6 +119,10 @@ def scrape(
         str | None,
         typer.Option("--user-agent", "-A", help="Custom User-Agent header."),
     ] = None,
+    platform: Annotated[
+        Platform,
+        typer.Option("--platform", "-p", help="Ecommerce platform: shopify, woocommerce."),
+    ] = Platform.shopify,
     verbose: Annotated[
         bool,
         typer.Option("--verbose", "-v", help="Show debug output."),
@@ -121,7 +132,7 @@ def scrape(
         typer.Option("--quiet", "-q", help="Show only warnings and errors."),
     ] = False,
 ) -> None:
-    """Scrape products and collections from Shopify stores."""
+    """Scrape products and collections from Shopify and WooCommerce stores."""
     # Load config file (or defaults)
     config = load_config(config_path)
 
@@ -153,7 +164,7 @@ def scrape(
     log_level = "DEBUG" if verbose else "WARNING" if quiet else None
 
     # Run the spider
-    run_spider(all_urls, config, log_level=log_level)
+    run_spider(all_urls, config, log_level=log_level, platform=platform)
 
 
 @app.command()
@@ -245,13 +256,32 @@ def get_urls(urls: list[str] | None, url_file: Path | None) -> list[str]:
     return []
 
 
-def run_spider(urls: list[str], config: Config, log_level: str | None = None) -> None:
-    """Run the Shopify spider with the given configuration."""
+def run_spider(
+    urls: list[str],
+    config: Config,
+    log_level: str | None = None,
+    platform: Platform = Platform.shopify,
+) -> None:
+    """Run the appropriate spider with the given configuration."""
     # Deferred imports to avoid loading Scrapy until needed
     from scrapy.crawler import CrawlerProcess
     from scrapy.utils.project import get_project_settings
 
-    from shopify_spy.spiders.shopify import ShopifySpider
+    if platform == Platform.woocommerce:
+        from shopify_spy.spiders.woocommerce import WooCommerceSpider
+
+        spider_cls = WooCommerceSpider
+        spider_kwargs: dict = {"images": config.scrape.images}
+    else:
+        from shopify_spy.spiders.shopify import ShopifySpider
+
+        spider_cls = ShopifySpider
+        spider_kwargs = {
+            "products": config.scrape.products,
+            "collections": config.scrape.collections,
+            "images": config.scrape.images,
+            "limit": config.scrape.limit,
+        }
 
     settings = get_project_settings()
 
@@ -298,8 +328,10 @@ def run_spider(urls: list[str], config: Config, log_level: str | None = None) ->
         settings.set("ITEM_PIPELINES", {})
 
     console.print(f"[bold]Scraping {len(urls)} store(s)...[/bold]")
-    console.print(f"  Products: {config.scrape.products}")
-    console.print(f"  Collections: {config.scrape.collections}")
+    console.print(f"  Platform: {platform.value}")
+    if platform == Platform.shopify:
+        console.print(f"  Products: {config.scrape.products}")
+        console.print(f"  Collections: {config.scrape.collections}")
     console.print(f"  Images: {config.scrape.images}")
     console.print(f"  Format: {config.output.format}")
     console.print(f"  Output: {output_dir}")
@@ -308,14 +340,7 @@ def run_spider(urls: list[str], config: Config, log_level: str | None = None) ->
 
     # Crawl each URL
     for store_url in urls:
-        process.crawl(
-            ShopifySpider,
-            url=store_url,
-            products=config.scrape.products,
-            collections=config.scrape.collections,
-            images=config.scrape.images,
-            limit=config.scrape.limit,
-        )
+        process.crawl(spider_cls, url=store_url, **spider_kwargs)
 
     process.start()
     console.print("[green]Done![/green]")

--- a/shopify_spy/cli.py
+++ b/shopify_spy/cli.py
@@ -325,7 +325,7 @@ def run_spider(
         settings.set("ITEM_PIPELINES", {})
 
     console.print(f"[bold]Scraping {len(urls)} store(s)...[/bold]")
-    console.print(f"  Platform: {config.scrape.platform}")
+    console.print(f"  Platform: {config.scrape.platform.value}")
     if config.scrape.platform == Platform.shopify:
         console.print(f"  Products: {config.scrape.products}")
         console.print(f"  Collections: {config.scrape.collections}")

--- a/shopify_spy/config.py
+++ b/shopify_spy/config.py
@@ -13,11 +13,13 @@ OUTPUT_FORMATS: dict[str, tuple[str, str]] = {
     "xml": ("xml", ".xml"),
 }
 OutputFormat = Literal["json", "jsonl", "csv", "xml"]
+PlatformType = Literal["shopify", "woocommerce"]
 
 
 class ScrapeConfig(BaseModel):
     """Configuration for what to scrape."""
 
+    platform: PlatformType = "shopify"
     products: bool = True
     collections: bool = False
     images: bool = False
@@ -77,8 +79,9 @@ DEFAULT_CONFIG_YAML = """\
 # See https://github.com/ndgigliotti/shopify-spy for documentation
 
 scrape:
-  products: true      # Scrape product data
-  collections: false  # Scrape collection data
+  platform: shopify   # Platform: shopify, woocommerce
+  products: true      # Scrape product data (Shopify only)
+  collections: false  # Scrape collection data (Shopify only)
   images: false       # Download product images
 
 output:

--- a/shopify_spy/config.py
+++ b/shopify_spy/config.py
@@ -1,5 +1,6 @@
 """YAML configuration loading and Pydantic models."""
 
+from enum import Enum
 from pathlib import Path
 from typing import Literal
 
@@ -13,13 +14,17 @@ OUTPUT_FORMATS: dict[str, tuple[str, str]] = {
     "xml": ("xml", ".xml"),
 }
 OutputFormat = Literal["json", "jsonl", "csv", "xml"]
-PlatformType = Literal["shopify", "woocommerce"]
+
+
+class Platform(str, Enum):
+    shopify = "shopify"
+    woocommerce = "woocommerce"
 
 
 class ScrapeConfig(BaseModel):
     """Configuration for what to scrape."""
 
-    platform: PlatformType = "shopify"
+    platform: Platform = Platform.shopify
     products: bool = True
     collections: bool = False
     images: bool = False

--- a/shopify_spy/spiders/shopify.py
+++ b/shopify_spy/spiders/shopify.py
@@ -8,7 +8,7 @@ import scrapy
 from scrapy.exceptions import CloseSpider
 from scrapy.http import Response
 
-from shopify_spy.utils import as_bool, find_all_values
+from shopify_spy.utils import as_bool, find_all_values, normalize_url
 
 
 class ShopifySpider(scrapy.spiders.SitemapSpider):
@@ -125,9 +125,5 @@ def extract_data(response: Response) -> dict[str, Any]:
 
 def get_sitemap_url(url: str) -> str:
     """Infer sitemap URL from given URL, normalizing if needed."""
-    parsed = urllib.parse.urlparse(url)
-    if not parsed.scheme:
-        # Assume https if no scheme provided
-        parsed = urllib.parse.urlparse(f"https://{url}")
-    sitemap_url = (parsed.scheme, parsed.netloc, "sitemap.xml", "", "", "")
-    return urllib.parse.urlunparse(sitemap_url)
+    parsed = normalize_url(url)
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "sitemap.xml", "", "", ""))

--- a/shopify_spy/spiders/woocommerce.py
+++ b/shopify_spy/spiders/woocommerce.py
@@ -1,0 +1,97 @@
+import json
+import urllib.parse
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
+from shopify_spy.utils import as_bool
+
+
+class WooCommerceSpider(scrapy.Spider):
+    """Paginated API spider for scraping WooCommerce stores.
+
+    Uses the public WooCommerce Store API (no authentication required).
+
+    Usage examples:
+    scrapy crawl woocommerce_spider -a url=https://www.example.com/
+    scrapy crawl woocommerce_spider -a url_file=resources/urls.txt
+    """
+
+    name = "woocommerce_spider"
+
+    def __init__(
+        self,
+        *args: Any,
+        url: str | None = None,
+        url_file: str | None = None,
+        images: bool | str = True,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize spider with store URL(s).
+
+        Args:
+            url: Complete URL of target WooCommerce store.
+            url_file: Path to text file with one URL per line.
+            images: Whether to collect image URLs.
+        """
+        if url:
+            self._store_urls = [url]
+        elif url_file:
+            with open(url_file) as f:
+                self._store_urls = [line.strip() for line in f if line.strip()]
+        else:
+            self._store_urls = []
+
+        self.images_enabled = as_bool(images)
+        super().__init__(*args, **kwargs)
+
+    async def start(self) -> AsyncGenerator[scrapy.Request]:
+        for url in self._store_urls:
+            yield scrapy.Request(get_api_url(url, page=1), callback=self.parse)
+
+    def parse(self, response: Response) -> Generator[dict[str, Any] | scrapy.Request]:
+        """Yield products from one page of the Store API and follow pagination.
+
+        @url https://woo.com/wp-json/wc/store/v1/products?per_page=100&page=1
+        @returns items 1
+        @returns requests 1 1
+        @scrapes id name store image_urls
+        """
+        products: list[dict[str, Any]] = json.loads(response.text)
+        if not products:
+            return
+
+        store = urllib.parse.urlparse(response.request.url).netloc
+
+        for product in products:
+            product["store"] = store
+            if self.images_enabled:
+                product["image_urls"] = [img["src"] for img in product.get("images", [])]
+            else:
+                product["image_urls"] = []
+            yield product
+
+        yield scrapy.Request(next_page_url(response.request.url), callback=self.parse)
+
+
+def get_api_url(store_url: str, page: int = 1) -> str:
+    """Build WooCommerce Store API URL for the given store and page."""
+    parsed = urllib.parse.urlparse(store_url)
+    if not parsed.scheme:
+        parsed = urllib.parse.urlparse(f"https://{store_url}")
+    query = urllib.parse.urlencode({"per_page": 100, "page": page})
+    return urllib.parse.urlunparse(
+        (parsed.scheme, parsed.netloc, "/wp-json/wc/store/v1/products", "", query, "")
+    )
+
+
+def next_page_url(url: str) -> str:
+    """Increment the page parameter in a Store API URL."""
+    parsed = urllib.parse.urlparse(url)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    params["page"] = int(params.get("page", 1)) + 1
+    return urllib.parse.urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path, "", urllib.parse.urlencode(params), "")
+    )

--- a/shopify_spy/spiders/woocommerce.py
+++ b/shopify_spy/spiders/woocommerce.py
@@ -6,7 +6,7 @@ from typing import Any
 import scrapy
 from scrapy.http import Response
 
-from shopify_spy.utils import as_bool
+from shopify_spy.utils import as_bool, normalize_url
 
 
 class WooCommerceSpider(scrapy.Spider):
@@ -78,9 +78,7 @@ class WooCommerceSpider(scrapy.Spider):
 
 def get_api_url(store_url: str, page: int = 1) -> str:
     """Build WooCommerce Store API URL for the given store and page."""
-    parsed = urllib.parse.urlparse(store_url)
-    if not parsed.scheme:
-        parsed = urllib.parse.urlparse(f"https://{store_url}")
+    parsed = normalize_url(store_url)
     query = urllib.parse.urlencode({"per_page": 100, "page": page})
     return urllib.parse.urlunparse(
         (parsed.scheme, parsed.netloc, "/wp-json/wc/store/v1/products", "", query, "")

--- a/shopify_spy/utils.py
+++ b/shopify_spy/utils.py
@@ -1,7 +1,16 @@
+import urllib.parse
 from collections.abc import Iterator
 from typing import Any
 
 import scrapy
+
+
+def normalize_url(url: str) -> urllib.parse.ParseResult:
+    """Parse a URL, assuming https if no scheme is provided."""
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.scheme:
+        parsed = urllib.parse.urlparse(f"https://{url}")
+    return parsed
 
 
 def find_all_values(key: str, obj: Any) -> Iterator[Any]:

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 import re
 import subprocess
 import sys
@@ -5,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import scrapy
 from typer.testing import CliRunner
 
 from shopify_spy.cli import app, apply_cli_overrides, get_urls, run_spider
@@ -18,6 +21,7 @@ from shopify_spy.config import (
     load_config_from_file,
 )
 from shopify_spy.spiders.shopify import ShopifySpider, extract_data, get_sitemap_url
+from shopify_spy.spiders.woocommerce import WooCommerceSpider, get_api_url, next_page_url
 from shopify_spy.utils import as_bool, find_all_values, uri_params
 
 runner = CliRunner()
@@ -35,6 +39,12 @@ def strip_ansi(text: str) -> str:
 def test_contracts():
     """Integration test that hits real Shopify endpoints via Scrapy contracts."""
     subprocess.run([sys.executable, "-m", "scrapy", "check", "shopify_spider"], check=True)
+
+
+@pytest.mark.integration
+def test_woocommerce_contracts():
+    """Integration test that hits real WooCommerce endpoints via Scrapy contracts."""
+    subprocess.run([sys.executable, "-m", "scrapy", "check", "woocommerce_spider"], check=True)
 
 
 # --- get_sitemap_url tests ---
@@ -332,6 +342,15 @@ def test_cli_scrape_help():
     assert "--products" in output
     assert "--no-products" in output
     assert "--url-file" in output
+    assert "--platform" in output
+
+
+def test_cli_scrape_help_platform_values():
+    result = runner.invoke(app, ["scrape", "--help"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.stdout)
+    assert "shopify" in output
+    assert "woocommerce" in output
 
 
 def test_cli_init_help():
@@ -653,6 +672,7 @@ def test_apply_cli_overrides_limit():
     config = Config()
     overridden = apply_cli_overrides(
         config,
+        platform=None,
         products=None,
         collections=None,
         images=None,
@@ -721,3 +741,179 @@ def test_run_spider_passes_limit_to_crawl(tmp_path):
 
     _, kwargs = mock_process.crawl.call_args
     assert kwargs["limit"] == 5
+
+
+# --- WooCommerce get_api_url tests ---
+
+
+def test_get_api_url_basic():
+    assert get_api_url("https://store.com") == (
+        "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+    )
+
+
+def test_get_api_url_page():
+    assert get_api_url("https://store.com", page=3) == (
+        "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=3"
+    )
+
+
+def test_get_api_url_strips_path():
+    assert get_api_url("https://store.com/some/path/") == (
+        "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+    )
+
+
+def test_get_api_url_no_scheme():
+    assert get_api_url("store.com") == (
+        "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+    )
+
+
+# --- WooCommerce next_page_url tests ---
+
+
+def test_next_page_url():
+    url = "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+    assert next_page_url(url) == (
+        "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=2"
+    )
+
+
+def test_next_page_url_increments():
+    url = "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=5"
+    assert next_page_url(url) == (
+        "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=6"
+    )
+
+
+# --- WooCommerceSpider __init__ tests ---
+
+
+def test_woocommerce_spider_init_url():
+    spider = WooCommerceSpider(url="https://store.com")
+    assert spider._store_urls == ["https://store.com"]
+    assert spider.images_enabled is True
+
+
+def test_woocommerce_spider_init_url_file(tmp_path):
+    url_file = tmp_path / "urls.txt"
+    url_file.write_text("https://store1.com\n\nhttps://store2.com\n")
+    spider = WooCommerceSpider(url_file=str(url_file))
+    assert spider._store_urls == ["https://store1.com", "https://store2.com"]
+
+
+def test_woocommerce_spider_init_no_url():
+    spider = WooCommerceSpider()
+    assert spider._store_urls == []
+
+
+def test_woocommerce_spider_init_images_false():
+    spider = WooCommerceSpider(url="https://store.com", images=False)
+    assert spider.images_enabled is False
+
+
+# --- WooCommerceSpider start tests ---
+
+
+def _collect_start(spider):
+    async def _inner():
+        return [r async for r in spider.start()]
+
+    return asyncio.run(_inner())
+
+
+def test_woocommerce_spider_start():
+    spider = WooCommerceSpider(url="https://store.com")
+    requests = _collect_start(spider)
+    assert len(requests) == 1
+    assert requests[0].url == ("https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1")
+
+
+def test_woocommerce_spider_start_multiple():
+    spider = WooCommerceSpider()
+    spider._store_urls = ["https://store1.com", "https://store2.com"]
+    requests = _collect_start(spider)
+    assert len(requests) == 2
+    assert "store1.com" in requests[0].url
+    assert "store2.com" in requests[1].url
+
+
+# --- WooCommerceSpider parse tests ---
+
+_PRODUCT_JSON = json.dumps(
+    [
+        {
+            "id": 1,
+            "name": "Widget",
+            "slug": "widget",
+            "permalink": "https://store.com/product/widget/",
+            "sku": "WGT-001",
+            "prices": {"price": "1000", "currency_code": "USD", "currency_minor_unit": 2},
+            "images": [
+                {"id": 10, "src": "https://store.com/img/widget.jpg"},
+                {"id": 11, "src": "https://store.com/img/widget-2.jpg"},
+            ],
+            "categories": [],
+        }
+    ]
+)
+
+
+def test_woocommerce_parse_yields_product():
+    spider = WooCommerceSpider(url="https://store.com", images=True)
+
+    mock_response = Mock()
+    mock_response.text = _PRODUCT_JSON
+    mock_response.request.url = "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+
+    results = list(spider.parse(mock_response))
+    items = [r for r in results if isinstance(r, dict)]
+    requests = [r for r in results if isinstance(r, scrapy.Request)]
+
+    assert len(items) == 1
+    assert items[0]["id"] == 1
+    assert items[0]["name"] == "Widget"
+    assert items[0]["store"] == "store.com"
+    assert items[0]["image_urls"] == [
+        "https://store.com/img/widget.jpg",
+        "https://store.com/img/widget-2.jpg",
+    ]
+    assert len(requests) == 1
+    assert "page=2" in requests[0].url
+
+
+def test_woocommerce_parse_no_images():
+    spider = WooCommerceSpider(url="https://store.com", images=False)
+
+    mock_response = Mock()
+    mock_response.text = _PRODUCT_JSON
+    mock_response.request.url = "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+
+    results = list(spider.parse(mock_response))
+    items = [r for r in results if isinstance(r, dict)]
+
+    assert items[0]["image_urls"] == []
+
+
+def test_woocommerce_parse_empty_stops_pagination():
+    spider = WooCommerceSpider(url="https://store.com")
+
+    mock_response = Mock()
+    mock_response.text = "[]"
+    mock_response.request.url = "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=5"
+
+    results = list(spider.parse(mock_response))
+    assert results == []
+
+
+def test_woocommerce_parse_product_no_images_field():
+    spider = WooCommerceSpider(url="https://store.com", images=True)
+
+    mock_response = Mock()
+    mock_response.text = json.dumps([{"id": 2, "name": "No-image product", "images": []}])
+    mock_response.request.url = "https://store.com/wp-json/wc/store/v1/products?per_page=100&page=1"
+
+    results = list(spider.parse(mock_response))
+    items = [r for r in results if isinstance(r, dict)]
+    assert items[0]["image_urls"] == []

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,7 @@ import pytest
 import scrapy
 from typer.testing import CliRunner
 
-from shopify_spy.cli import app, apply_cli_overrides, get_urls, run_spider
+from shopify_spy.cli import Platform, app, apply_cli_overrides, get_urls, run_spider
 from shopify_spy.config import (
     OUTPUT_FORMATS,
     Config,
@@ -395,6 +395,7 @@ def test_cli_scrape_no_url():
 
 def test_config_defaults():
     config = Config()
+    assert config.scrape.platform == "shopify"
     assert config.scrape.products is True
     assert config.scrape.collections is False
     assert config.scrape.images is False
@@ -413,6 +414,7 @@ def test_load_config_from_file(tmp_path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text("""
 scrape:
+  platform: woocommerce
   products: false
   collections: true
   images: false
@@ -422,6 +424,7 @@ network:
   concurrent_requests: 8
 """)
     config = load_config_from_file(config_file)
+    assert config.scrape.platform == "woocommerce"
     assert config.scrape.products is False
     assert config.scrape.collections is True
     assert config.scrape.images is False
@@ -465,6 +468,7 @@ def test_apply_cli_overrides():
     config = Config()
     overridden = apply_cli_overrides(
         config,
+        platform=Platform.woocommerce,
         products=False,
         collections=True,
         images=None,  # should not override
@@ -475,6 +479,7 @@ def test_apply_cli_overrides():
         limit=10,
         user_agent="MyBot/1.0",
     )
+    assert overridden.scrape.platform == "woocommerce"
     assert overridden.scrape.products is False
     assert overridden.scrape.collections is True
     assert overridden.scrape.images is False  # unchanged (default)
@@ -490,6 +495,7 @@ def test_apply_cli_overrides_none_values():
     config = Config()
     overridden = apply_cli_overrides(
         config,
+        platform=None,
         products=None,
         collections=None,
         images=None,
@@ -500,6 +506,7 @@ def test_apply_cli_overrides_none_values():
         limit=None,
         user_agent=None,
     )
+    assert overridden.scrape.platform == "shopify"  # default
     assert overridden.scrape.products is True
     assert overridden.scrape.collections is False
     assert overridden.scrape.limit is None
@@ -574,6 +581,7 @@ def test_apply_cli_overrides_format():
     config = Config()
     overridden = apply_cli_overrides(
         config,
+        platform=None,
         products=None,
         collections=None,
         images=None,
@@ -592,6 +600,7 @@ def test_apply_cli_overrides_format_none():
     config = Config()
     overridden = apply_cli_overrides(
         config,
+        platform=None,
         products=None,
         collections=None,
         images=None,

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-03-23T23:05:13.205302678Z"
+exclude-newer = "2026-03-24T00:50:25.53278744Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1345,7 +1345,7 @@ wheels = [
 
 [[package]]
 name = "shopify-spy"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- Adds `WooCommerceSpider` using the public WooCommerce Store API (`/wp-json/wc/store/v1/products`) -- no authentication required, paginates until empty response
- Adds `--platform, -p` CLI flag (default: `shopify`) to route between spiders
- Moves `Platform` enum into `config.py` (replacing a `Literal` alias) so config models and CLI share one definition
- Extracts URL scheme-normalization into `normalize_url()` in `utils.py`, used by both spiders
- Updates README with platform table, WooCommerce output shape, and limitations note

## Test plan

- [ ] `uv run pytest` -- 81 tests pass
- [ ] `uv run scrapy check woocommerce_spider` -- contract passes against woo.com
- [ ] `shopify-spy scrape --platform woocommerce https://woo.com` -- products scraped
- [ ] `shopify-spy scrape https://www.snowdevil.ca` -- Shopify still works, no regression